### PR TITLE
Changes the way that team Elos are calculated

### DIFF
--- a/HandballBackend/Database/Models/Person.cs
+++ b/HandballBackend/Database/Models/Person.cs
@@ -89,13 +89,8 @@ public class Person {
                 return pgs.InitialElo;
             }
         }
-
-        var player = PlayerGameStats?.OrderByDescending(pgs => pgs.GameId).FirstOrDefault();
-        if (player is { EloDelta: not null }) {
-            return (double) (player.EloDelta + player.InitialElo);
-        }
-
-        return player?.InitialElo ?? 1500.0;
+        
+        return EloCalculator.GetPlayerElos().GetValueOrDefault(Id, 1500);
     }
 
     public PersonData ToSendableData(

--- a/HandballBackend/Database/Models/Person.cs
+++ b/HandballBackend/Database/Models/Person.cs
@@ -89,7 +89,7 @@ public class Person {
                 return pgs.InitialElo;
             }
         }
-        
+
         return EloCalculator.GetPlayerElos().GetValueOrDefault(Id, 1500);
     }
 

--- a/HandballBackend/Database/Models/Team.cs
+++ b/HandballBackend/Database/Models/Team.cs
@@ -57,7 +57,7 @@ public class Team : IHasRelevant<Team> {
 
     [NotMapped]
     public List<Person> People =>
-        new List<Person?> {Captain, NonCaptain, Substitute}
+        new List<Person?> { Captain, NonCaptain, Substitute }
             .Where(p => p != null)
             .Select(p => p!)
             .ToList();
@@ -83,7 +83,7 @@ public class Team : IHasRelevant<Team> {
             .Select(id => id!.Value);
 
         var allElos = EloCalculator.GetPlayerElos();
-        
+
         return ids.Select(id => allElos.GetValueOrDefault(id, 1500)).DefaultIfEmpty(1500).Average();
     }
 

--- a/HandballBackend/Database/Models/Team.cs
+++ b/HandballBackend/Database/Models/Team.cs
@@ -71,13 +71,17 @@ public class Team : IHasRelevant<Team> {
         return new TeamData(this, tournament, generateStats, generatePlayerStats, formatData);
     }
 
-    public double Elo(Tournament? tournament = null) {
+    public double DisplayElo(Tournament? tournament = null) {
         var lastGame = PlayerGameStats.OrderByDescending(pgs => pgs.TournamentId == tournament?.Id)
             .ThenByDescending(pgs => pgs.GameId).GroupBy(pgs => pgs.GameId).SelectMany(i => i)
             .Select(pgs => pgs.EloDelta + pgs.InitialElo).Where(elo => elo.HasValue).Cast<double>().ToList();
         if (lastGame.Count != 0) {
             return lastGame.Average();
         }
+        return TrueElo();
+    }
+
+    public double TrueElo() {
         var ids = new[] { CaptainId, NonCaptainId, SubstituteId }
             .Where(id => id.HasValue)
             .Select(id => id!.Value);

--- a/HandballBackend/Database/SendableTypes/TeamData.cs
+++ b/HandballBackend/Database/SendableTypes/TeamData.cs
@@ -70,7 +70,7 @@ public class TeamData {
         if (!generateStats)
             return;
 
-        Elo = team.Elo(tournament);
+        Elo = team.DisplayElo(tournament);
 
         Stats = new Dictionary<string, dynamic>
         {

--- a/HandballBackend/Database/SendableTypes/TeamData.cs
+++ b/HandballBackend/Database/SendableTypes/TeamData.cs
@@ -70,7 +70,7 @@ public class TeamData {
         if (!generateStats)
             return;
 
-        Elo = team.Elo();
+        Elo = team.Elo(tournament);
 
         Stats = new Dictionary<string, dynamic>
         {

--- a/HandballBackend/FixtureGenerator/Pooled.cs
+++ b/HandballBackend/FixtureGenerator/Pooled.cs
@@ -21,7 +21,7 @@ public class Pooled : AbstractFixtureGenerator {
         var teams = (await db.TournamentTeams
             .Where(t => t.TournamentId == _tournamentId)
             .IncludeRelevant()
-            .ToArrayAsync()).OrderByDescending(t => t.Team.Elo()).ToList();
+            .ToArrayAsync()).OrderByDescending(t => t.Team.TrueElo()).ToList();
 
         var pool = 0;
         foreach (var team in teams) {

--- a/HandballBackend/UtilityFunctions.cs
+++ b/HandballBackend/UtilityFunctions.cs
@@ -35,7 +35,7 @@ internal static class UtilityFunctions {
         foreach (var game in games) {
             var isRandomAbandonment = Math.Max(game.TeamOneScore, game.TeamTwoScore) < 5 &&
                                       game.Events.Any(gE => gE.EventType == GameEventType.Abandon);
-            var shouldHaveDelta = game is {IsBye: false, IsFinal: false, Ranked: true} && !isRandomAbandonment &&
+            var shouldHaveDelta = game is { IsBye: false, IsFinal: false, Ranked: true } && !isRandomAbandonment &&
                                   game.Ended;
             var playingPlayers = game.Players
                 .Where(pgs =>
@@ -278,9 +278,9 @@ internal static class UtilityFunctions {
                 .Select(to => new AbstractFixtureGenerator.OfficialContainer {
                     PlayerId = to.Official.PersonId,
                     OfficialId = to.OfficialId,
-                    GamesUmpired = to.Official.Games.Count(g => g is {TournamentId: tournamentId, Round: < round}),
+                    GamesUmpired = to.Official.Games.Count(g => g is { TournamentId: tournamentId, Round: < round }),
                     Name = to.Official.Person.Name,
-                    GamesScored = to.Official.ScoredGames.Count(g => g is {TournamentId: tournamentId, Round: < round}),
+                    GamesScored = to.Official.ScoredGames.Count(g => g is { TournamentId: tournamentId, Round: < round }),
                     UmpireProficiency = to.UmpireProficiency,
                     ScorerProficiency = to.ScorerProficiency,
                 }).OrderBy(o => o.GamesUmpired).ToList();
@@ -319,7 +319,7 @@ internal static class UtilityFunctions {
         Console.WriteLine("--------------------");
         Console.WriteLine($"Success: {AbstractFixtureGenerator.TrySolution(solutionArray, officials, force: true)}");
         Console.WriteLine("--------------------");
-        foreach (var game in solutionArray.SelectMany(g => new[] {g.Item1, g.Item2})) {
+        foreach (var game in solutionArray.SelectMany(g => new[] { g.Item1, g.Item2 })) {
             if (game == null) continue;
             Console.WriteLine($"Game {game.GameId} on Court {game.CourtId + 1}");
             Console.WriteLine($"\tPlayers: {string.Join(", ", game.PlayerIds)}");

--- a/HandballBackend/Utils/EloCalculator.cs
+++ b/HandballBackend/Utils/EloCalculator.cs
@@ -26,6 +26,7 @@ public static class EloCalculator {
     private static double K = 40.0;
     private static double D = 3000.0;
 
+
     public static double InitialElo = 1500.0;
 
     private static double Probability(double opponentElo, double myElo) {
@@ -38,5 +39,33 @@ public static class EloCalculator {
         return delta;
     }
 
-    public static void CalculateElos(Game game, bool isForfeit) { }
+    private static Dictionary<int, double> _cachedElos = new();
+    private static int lastPgsID;
+
+    public static Dictionary<int, double> GetPlayerElos() {
+        var db = new HandballContext();
+        var lastId = db.PlayerGameStats.Select(pgs => pgs.Id).OrderByDescending(i => i).FirstOrDefault();
+        if (lastPgsID != lastId) {
+            lastPgsID = lastId;
+            _cachedElos =  db.PlayerGameStats
+                .Join(
+                    db.PlayerGameStats
+                        .GroupBy(s => s.PlayerId)
+                        .Select(g => new {
+                            PlayerId = g.Key,
+                            GameId = g.Max(x => x.GameId)
+                        }),
+                    pgs => new { pgs.PlayerId, pgs.GameId },
+                    latest => new { latest.PlayerId, latest.GameId },
+                    (pgs, latest) => new {
+                        pgs.PlayerId,
+                        Elo = (pgs.EloDelta ?? 0) + pgs.InitialElo
+                    }
+                )
+                .ToDictionary(x => x.PlayerId, x => x.Elo);
+
+        }
+
+        return _cachedElos;
+    }
 }

--- a/HandballBackend/Utils/EloCalculator.cs
+++ b/HandballBackend/Utils/EloCalculator.cs
@@ -47,7 +47,7 @@ public static class EloCalculator {
         var lastId = db.PlayerGameStats.Select(pgs => pgs.Id).OrderByDescending(i => i).FirstOrDefault();
         if (lastPgsID != lastId) {
             lastPgsID = lastId;
-            _cachedElos =  db.PlayerGameStats
+            _cachedElos = db.PlayerGameStats
                 .Join(
                     db.PlayerGameStats
                         .GroupBy(s => s.PlayerId)


### PR DESCRIPTION
A teams elo is now displayed as the average elo of the last time they played together, unless they have never played in which case it is their current average elo.  It is also now calculated using a cache instead of using evil SQL requests