### PR TITLE
Change how non-player points are recorded

### DIFF
--- a/HandballBackend/EndpointHelpers/GameManagement/GameEventSynchroniser.cs
+++ b/HandballBackend/EndpointHelpers/GameManagement/GameEventSynchroniser.cs
@@ -287,7 +287,7 @@ internal static class GameEventSynchroniser {
             receivingPlayer = nonServingTeam.FirstOrDefault(pgs => (pgs?.CardTimeRemaining ?? 1) == 0);
         }
 
-        if (receivingPlayer != null && gameEvent.Notes != "Penalty") {
+        if (receivingPlayer != null && gameEvent.PlayerId != null) {
             receivingPlayer.ServesReceived += 1;
             if (gameEvent.Notes != "Ace") {
                 receivingPlayer.ServesReturned += 1;

--- a/HandballBackend/EndpointHelpers/GameManagement/GameManager.cs
+++ b/HandballBackend/EndpointHelpers/GameManagement/GameManager.cs
@@ -684,13 +684,13 @@ public static class GameManager {
         game.Length = Utilities.GetUnixSeconds() - game.StartTime;
         GameEventSynchroniser.SyncGameEnd(game, endEvent);
         if (!isRandomAbandonment && game is {
-                Ranked:
+            Ranked:
                 true,
-                IsFinal:
+            IsFinal:
                 false,
-                TeamOne.NonCaptainId: not null,
-                TeamTwo.NonCaptain: not null
-            }) {
+            TeamOne.NonCaptainId: not null,
+            TeamTwo.NonCaptain: not null
+        }) {
             var playingPlayers = game.Players
                 .Where(pgs => (isForfeit || pgs.RoundsCarded + pgs.RoundsOnCourt > 0)).ToList();
             var playingPlayerIds = playingPlayers.Select(pgs => pgs.PlayerId).ToList();
@@ -821,7 +821,7 @@ public static class GameManager {
         var ranked = tournament.Ranked;
         var isBye = false;
         var tasks = new List<Task>();
-        foreach (var team in new[] {teamOne, teamTwo}) {
+        foreach (var team in new[] { teamOne, teamTwo }) {
             if (team.Id == 1) {
                 // this is the bye team
                 isBye = true;
@@ -906,7 +906,7 @@ public static class GameManager {
             .ToDictionaryAsync(pgs => pgs!.PlayerId);
 
         tasks.Clear();
-        foreach (var team in new[] {teamOne, teamTwo}) {
+        foreach (var team in new[] { teamOne, teamTwo }) {
             if (team.Id == 1) continue;
             Person?[] teamPlayers = [team.Captain, team.NonCaptain, team.Substitute];
             foreach (var p in teamPlayers.Where(p => p != null).Cast<Person>()) {


### PR DESCRIPTION
Changes the way that points which are not scored are saved; they are now found by checking if the event player is null, instead of if the score type is "Penalty"